### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server that provides Swiss weather forecast data from LandiWetter. The server allows you to search for Swiss locations and get detailed weather forecasts.
 
+<a href="https://glama.ai/mcp/servers/@nabossha/mcp-landiwetter">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nabossha/mcp-landiwetter/badge" alt="LandiWetter Server MCP server" />
+</a>
+
 ## Features
 
 - Search for Swiss locations by name


### PR DESCRIPTION
This PR adds a badge for the [LandiWetter MCP Server](https://glama.ai/mcp/servers/@nabossha/mcp-landiwetter) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@nabossha/mcp-landiwetter">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nabossha/mcp-landiwetter/badge" alt="LandiWetter Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.